### PR TITLE
changed the default radius to be 50 miles

### DIFF
--- a/fireflight/src/components/PublicMap.jsx
+++ b/fireflight/src/components/PublicMap.jsx
@@ -75,7 +75,6 @@ const PublicMap = ({
       transitionDuration: 500
     })
     // setAddress('') // doesn't reset address because of the special Geocoder library
-    setRadius('')
   }
 
   const tempLocationPopup = (
@@ -219,7 +218,7 @@ const PublicMap = ({
         />
         <form onSubmit={handleSubmit} className="map-form-container">
           <label className="map-form-text">
-            Enter the address you wish to check fire proximity to.
+            Enter the address and radius you wish to check fire proximity to.
           </label>
           <Geocoder
             {...mapAccess}
@@ -235,7 +234,7 @@ const PublicMap = ({
             type="number"
             name="Radius"
             placeholder="mi"
-            value={radius}
+            value={radius ? radius : 50}
             onChange={e => setRadius(e.target.value)}
           />
           <button className="form-btn">Search</button>


### PR DESCRIPTION
# Description
changed the default radius to be 50 miles and to remind the user to enter a radius in the search bar text as well as not resetting the radius after submit. It might be helpful to add a tooltip to the radius input to let users know once more that is for the radius. 
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

- [ ] Test A
- [ ] Test B

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
